### PR TITLE
Bring in newer version of socks5-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"url": "https://github.com/mattcg/socks5-http-client.git"
 	},
 	"dependencies": {
-		"socks5-client": "0.x"
+		"socks5-client": "~0.3.4"
 	},
 	"devDependencies": {
 		"mocha": "1.x",


### PR DESCRIPTION
This is to fix an issue in node >0.10.0, see https://github.com/mattcg/socks5-client/commit/8a70fa1d692fc202adf49491d6f06bac1546f04c#diff-e8acc63b1e238f3255c900eed37254b8
