### PR TITLE
Added export of Agent to allow using HTTP keep-alive

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,8 @@ exports.request = function(options, cb) {
 	return http.request(options, cb);
 };
 
+exports.Agent = Agent;
+
 exports.get = function(options, cb) {
 	var req = exports.request(options, cb);
 


### PR DESCRIPTION
When using HTTP keep-alive, one must use the same instance of the Agent class for multiple requests. Therefore, Agent must be exported.
Together with the changes on socks5-client, this enables using HTTP keep-alive when using a SOCKS5 proxy.