### PR TITLE
Remove npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
 		"url": "https://github.com/mattcg/socks5-http-client.git"
 	},
 	"dependencies": {
-		"npm": "^5.8.0",
 		"socks5-client": "~1.2.6"
 	},
 	"devDependencies": {


### PR DESCRIPTION
This module should not depend on `npm`, and the dependency chain has known security advisories.

socks5-http-client@1.0.3 > npm@5.10.0 > request@2.85.0 > stringstream@0.0.5
See: https://nodesecurity.io/advisories/664